### PR TITLE
Give plugins access to channel info and allow them to set the topic.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 PyYAML==3.11
-slacker==0.1
+slacker==0.4

--- a/slackard.py
+++ b/slackard.py
@@ -125,6 +125,16 @@ class Slackard(object):
                                 filename=filename,
                                 title=title)
 
+    def set_topic(self, topic):
+        channels = self.chan_id
+        if topic is None:
+            topic = ''
+        self.slack.channels.set_topic(channel=channels, topic=topic)
+
+    def channel_info(self):
+        info = self.slack.channels.info(channel=self.chan_id)
+        return info.body['channel']
+
     def run(self):
         self._init_connection()
         self._import_plugins()


### PR DESCRIPTION
A plugin I'm fiddling with needed read/write access to the channel's topic.  Had to bump the required version of slacker to latest.
