### PR TITLE
Fetch User Info For a Message

### DIFF
--- a/plugins/compliment.py
+++ b/plugins/compliment.py
@@ -1,0 +1,5 @@
+from . import bot
+
+@bot.subscribe('^.compliment', include_user_info=True)
+def compliment(message, user_info):
+    bot.speak("Gee <@%s>...you're pretty swell." % user_info["id"])


### PR DESCRIPTION
I needed the information, id and name, for person sending the message.  Didn't want every plugin to force an api call for every message it receives so just made it an optional parameter when the plugin subscribes.  In the future adding some caching functionality around the user info fetch would probably be handy to avoid redundant calls.

Feel free to close if you don't want to merge.  No big deal.
