### PR TITLE
Pass structured messages instead of just text

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ bot. If a message matches then the entire message is passed.
 ```python
 @bot.subscribe('cookie')
 def sub_cookie(message):
-    bot.speak('I see a cookie in "{0}"'.format(message))
+    bot.speak('I see a cookie in "{0}"'.format(message['text']))
 ```
 
 ### Firehose

--- a/plugins/applause.py
+++ b/plugins/applause.py
@@ -4,10 +4,10 @@ import re
 @bot.firehose
 def listen(message):
     # Attempt to strip out URLs
-    message= re.sub('(https?|ftp)://\S+', '', message)
+    message= re.sub('(https?|ftp)://\S+', '', message['text'])
 
     pattern = "applau(d|se)|bravo|slow clap"
-    m = re.search(pattern, message, re.IGNORECASE)
+    m = re.search(pattern, message['text'], re.IGNORECASE)
     if m:
         image = 'http://i.imgur.com/9Zv4V.gif'
         bot.speak(image)

--- a/plugins/sub_cookie.py
+++ b/plugins/sub_cookie.py
@@ -3,4 +3,4 @@ from . import bot
 
 @bot.subscribe('cookie')
 def sub_cookie(message):
-    bot.speak('I see a cookie in "{0}"'.format(message))
+    bot.speak('I see a cookie in "{0}"'.format(message['text']))

--- a/slackard.py
+++ b/slackard.py
@@ -170,12 +170,12 @@ class Slackard(object):
                             continue
                     except KeyError:
                         pass
-                    print(message['text'])
+                    print(message)
                     for f in self.firehoses:
-                        f(message['text'])
+                        f(message)
                     for (f, matcher) in self.subscribers:
                         if matcher.search(message['text']):
-                            f(message['text'])
+                            f(message)
                     m = cmd_matcher.match(message['text'])
                     if m:
                         cmd, args = m.groups()


### PR DESCRIPTION
this gives access to other relevant daa, like the user who wrote the message:

`{u'text': u'my message', u'type': u'message', u'user': u'U04RLJSBD', u'ts': u'1438878753.000084'}`